### PR TITLE
Proxied

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,21 @@ local redis, err = rc:connect{
 }
 ```
 
+## Proxy Mode
+
+Enable the `connection_is_proxied` parameter if connecting to Redis through a proxy service (e.g. Twemproxy).  
+These proxies generally only support a limited sub-set of Redis commands, those which do not require state and do not affect multiple keys.  
+Databases and transactions are also not supported.
+
+Proxy mode will disable switching to a DB on connect.  
+Unsupported commands (defaults to those not supported by Twemproxy) will return `nil, err` immediately rather than being sent to the proxy, which can result in dropped connections.
+
+`discard` will not be sent when adding connections to the keepalive pool
+
+
+## Disabled commands
+
+If configured as a table of commands, the command methods will be replaced by a function which immediately returns `nil, err` without forwarding the command to the server
 
 ## Default Parameters
 
@@ -115,16 +130,20 @@ local redis, err = rc:connect{
     connection_options = {}, -- pool, etc
     keepalive_timeout = 60000,
     keepalive_poolsize = 30,
-    
+
     host = "127.0.0.1",
     port = "6379",
     path = "",  -- unix socket path, e.g. /tmp/redis.sock
     password = "",
     db = 0,
-    
+
     master_name = "mymaster",
     role = "master",  -- master | slave | any
     sentinels = {},
+
+    connection_is_proxied = false,
+
+    disabled_commands = {},
 }
 ```
 

--- a/lib/resty/redis/connector.lua
+++ b/lib/resty/redis/connector.lua
@@ -103,7 +103,24 @@ local DEFAULTS = setmetatable({
     role = "master",  -- master | slave | any
     sentinels = {},
 
+    -- Redis proxies typically don't support full Redis capabilities
+    connection_is_proxied = false,
+
+    disabled_commands = {},
+
 }, fixed_field_metatable)
+
+
+-- This is the set of commands unsupported by Twemproxy
+local default_disabled_commands = {
+    "migrate", "move", "object", "randomkey", "rename", "renamenx", "scan",
+    "bitop", "msetnx", "blpop", "brpop", "brpoplpush", "psubscribe", "publish",
+    "punsubscribe", "subscribe", "unsubscribe", "discard", "exec", "multi",
+    "unwatch", "watch", "script", "auth", "echo", "select", "bgrewriteaof",
+    "bgsave", "client", "config", "dbsize", "debug", "flushall", "flushdb",
+    "info", "lastsave", "monitor", "save", "shutdown", "slaveof", "slowlog",
+    "sync", "time"
+}
 
 
 local _M = {
@@ -118,6 +135,11 @@ function _M.new(config)
     if not ok then
         return nil, config  -- err
     else
+        -- In proxied Redis mode disable default commands
+        if config.connection_is_proxied == true
+           and not next(config.disabled_commands) then
+            config.disabled_commands = default_disabled_commands
+        end
         return setmetatable({
             config = setmetatable(config, fixed_field_metatable)
         }, mt)
@@ -135,6 +157,7 @@ local function parse_dsn(params)
             return nil, "could not parse DSN: " .. tostring(err)
         end
 
+        -- TODO: Support a 'protocol' for proxied Redis?
         local fields
         if m[1] == "redis" then
             fields = { "password", "host", "port", "db" }
@@ -265,6 +288,15 @@ function _M.connect_to_host(self, host)
     local config = self.config
     r:set_timeout(config.connect_timeout)
 
+    -- Stub out methods for disabled commands
+    if next(config.disabled_commands) then
+        for _, cmd in ipairs(config.disabled_commands) do
+            r[cmd] = function(...)
+                return nil, ("Command "..cmd.." is disabled")
+            end
+        end
+    end
+
     local ok, err
     local path = host.path
     local opts = config.connection_options
@@ -296,7 +328,8 @@ function _M.connect_to_host(self, host)
             end
         end
 
-        if host.db ~= nil then
+        -- No support for DBs in proxied Redis.
+        if config.connection_is_proxied ~= true and host.db ~= nil then
             r:select(host.db)
         end
         return r, nil
@@ -307,7 +340,10 @@ end
 local function set_keepalive(self, redis)
     -- Restore connection to "NORMAL" before putting into keepalive pool,
     -- ignoring any errors.
-    redis:discard()
+    -- Proxied Redis does not support transactions.
+    if self.config.connection_is_proxied ~= true then
+        redis:discard()
+    end
 
     local config = self.config
     return redis:set_keepalive(

--- a/t/proxy.t
+++ b/t/proxy.t
@@ -1,0 +1,155 @@
+use Test::Nginx::Socket 'no_plan';
+use Cwd qw(cwd);
+
+my $pwd = cwd();
+
+our $HttpConfig = qq{
+lua_package_path "$pwd/lib/?.lua;;";
+
+init_by_lua_block {
+    require("luacov.runner").init()
+}
+};
+
+$ENV{TEST_NGINX_RESOLVER} = '8.8.8.8';
+$ENV{TEST_NGINX_REDIS_PORT} ||= 6379;
+
+no_long_string();
+run_tests();
+
+__DATA__
+
+=== TEST 1: Proxy mode disables commands
+--- http_config eval: $::HttpConfig
+--- config
+location /t {
+    content_by_lua_block {
+        local rc = require("resty.redis.connector").new({
+            port = $TEST_NGINX_REDIS_PORT,
+            connection_is_proxied = true
+        })
+
+        local redis, err = assert(rc:connect(params),
+            "connect should return positively")
+
+        assert(redis:set("dog", "an animal"),
+            "redis:set should return positively")
+
+        local ok, err = redis:multi()
+        assert(ok == nil, "redis:multi should return nil")
+        assert(err == "Command multi is disabled")
+
+        redis:close()
+    }
+}
+--- request
+GET /t
+--- no_error_log
+[error]
+
+
+=== TEST 2: Proxy mode disables custom commands
+--- http_config eval: $::HttpConfig
+--- config
+location /t {
+    content_by_lua_block {
+        local rc = require("resty.redis.connector").new({
+            port = $TEST_NGINX_REDIS_PORT,
+            connection_is_proxied = true,
+            disabled_commands = { "foobar", "hget"}
+        })
+
+        local redis, err = assert(rc:connect(params),
+            "connect should return positively")
+
+        assert(redis:set("dog", "an animal"),
+            "redis:set should return positively")
+
+        assert(redis:multi(),
+            "redis:multi should return positively")
+
+        local ok, err = redis:hget()
+        assert(ok == nil, "redis:hget should return nil")
+        assert(err == "Command hget is disabled")
+
+        local ok, err = redis:foobar()
+        assert(ok == nil, "redis:foobar should return nil")
+        assert(err == "Command foobar is disabled")
+
+        redis:close()
+    }
+}
+--- request
+GET /t
+--- no_error_log
+[error]
+
+=== TEST 3: Proxy mode does not switch DB
+--- http_config eval: $::HttpConfig
+--- config
+location /t {
+    content_by_lua_block {
+        local redis = require("resty.redis.connector").new({
+            port = $TEST_NGINX_REDIS_PORT,
+            db = 2
+        }):connect()
+
+        local proxy = require("resty.redis.connector").new({
+            port = $TEST_NGINX_REDIS_PORT,
+            connection_is_proxied = true,
+            db = 2
+        }):connect()
+
+        assert(redis:set("proxy", "test"),
+            "redis:set should return positively")
+
+        assert(proxy:get("proxy") == ngx.null,
+             "proxy key should not exist in proxy")
+
+        redis:seelct(2)
+        assert(redis:get("proxy") == "test",
+            "proxy key should be 'test' in db 1")
+
+        redis:close()
+    }
+}
+--- request
+GET /t
+--- no_error_log
+[error]
+
+
+=== TEST 4: Commands are disabled without proxy mode
+--- http_config eval: $::HttpConfig
+--- config
+location /t {
+    content_by_lua_block {
+        local rc = require("resty.redis.connector").new({
+            port = $TEST_NGINX_REDIS_PORT,
+            disabled_commands = { "foobar", "hget"}
+        })
+
+        local redis, err = assert(rc:connect(params),
+            "connect should return positively")
+
+        assert(redis:set("dog", "an animal"),
+            "redis:set should return positively")
+
+        assert(redis:multi(),
+            "redis:multi should return positively")
+
+        local ok, err = redis:hget()
+        assert(ok == nil, "redis:hget should return nil")
+        assert(err == "Command hget is disabled")
+
+        local ok, err = redis:foobar()
+        assert(ok == nil, "redis:foobar should return nil")
+        assert(err == "Command foobar is disabled")
+
+        redis:close()
+    }
+}
+--- request
+GET /t
+--- no_error_log
+[error]


### PR DESCRIPTION
Support for connecting to Redis through a sharding proxy like Twemproxy.

Disables transactional and state based commands.